### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_streamdeck"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 edition = "2024"
 authors = ["François Mockers <francois.mockers@vleue.com>"]
 description = "Elgato Stream Deck plugin for Bevy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_streamdeck"
-version = "0.6.0-rc.2"
+version = "0.6.0"
 edition = "2024"
 authors = ["François Mockers <francois.mockers@vleue.com>"]
 description = "Elgato Stream Deck plugin for Bevy"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For Linux setup, please refer to the [rust-streamdeck getting started guide](htt
 
 |Bevy|bevy_streamdeck|
 |---|---|
+|0.16|0.6|
 |0.15|0.5|
 |0.14|0.4|
 |0.13|0.3|


### PR DESCRIPTION



## 🤖 New release

* `bevy_streamdeck`: 0.6.0-rc.1 -> 0.6.0-rc.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).