### PR TITLE
chore: release v0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_streamdeck"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors = ["François Mockers <francois.mockers@vleue.com>"]
 description = "Elgato Stream Deck plugin for Bevy"


### PR DESCRIPTION



## 🤖 New release

* `bevy_streamdeck`: 0.8.0 -> 0.8.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).